### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lzokay"
-version = "1.0.1"
+version = "1.0.2"
 edition = "2018"
 license = "MIT"
 repository = "https://github.com/encounter/lzokay-rs"
@@ -20,5 +20,5 @@ compress = []
 default = ["compress", "decompress", "std"]
 
 [build-dependencies]
-bindgen = "0.59.1"
-cc = "1.0.69"
+bindgen = "0.72.1"
+cc = "1.2.41"

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,7 @@ fn main() {
         .ctypes_prefix("types")
         .derive_debug(false)
         .clang_arg("-std=c++14")
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks));
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()));
     #[cfg(not(feature = "std"))]
     {
         bindings = bindings.layout_tests(false);

--- a/src/compress.rs
+++ b/src/compress.rs
@@ -84,13 +84,15 @@ pub fn new_dict() -> Dict<'static> {
 }
 
 /// Dictionary storage size, for manual or stack allocation.
-pub const fn dict_storage_size() -> usize { size_of::<DictStorage>() }
+pub const fn dict_storage_size() -> usize {
+    size_of::<DictStorage>()
+}
 
 /// Creates a dictionary from the supplied storage.
 ///
 /// Storage **must** be at least [`dict_storage_size()`] bytes,
 /// otherwise this function will panic.
-pub fn dict_from_storage(storage: &mut [u8]) -> Dict {
+pub fn dict_from_storage(storage: &mut [u8]) -> Dict<'_> {
     if storage.len() < dict_storage_size() {
         panic!(
             "Dictionary storage is not large enough: {}, expected {}",
@@ -107,13 +109,17 @@ pub fn dict_from_storage(storage: &mut [u8]) -> Dict {
 }
 
 /// Worst-case compression size.
-pub const fn compress_worst_size(s: usize) -> usize { s + s / 16 + 64 + 3 }
+pub const fn compress_worst_size(s: usize) -> usize {
+    s + s / 16 + 64 + 3
+}
 
 /// Compress the supplied buffer into a heap-allocated vector.
 ///
 /// Creates a new dictionary for each invocation.
 #[cfg(feature = "alloc")]
-pub fn compress(src: &[u8]) -> Result<Vec<u8>, Error> { compress_with_dict(src, &mut new_dict()) }
+pub fn compress(src: &[u8]) -> Result<Vec<u8>, Error> {
+    compress_with_dict(src, &mut new_dict())
+}
 
 /// Compress the supplied buffer into a heap-allocated vector,
 /// with the supplied pre-allocated dictionary.


### PR DESCRIPTION
Updates lzokay to latest commit
Updates cc and bindgen to latest versions

Current commit of lzokay fails to build in GCC 12+

Current dependencies of cc/bindgen get stuck building forever without the dependency updates.